### PR TITLE
Make initial boot OS configurable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,19 +6,13 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-    reviewers:
-      - "ironcore-dev/core"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-    reviewers:
-      - "ironcore-dev/core"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-    reviewers:
-      - "ironcore-dev/core"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 5m
+  deadline: 10m
   allow-parallel-runners: true
 
 issues:

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -63,6 +63,7 @@ func main() {
 	var insecure bool
 	var managerNamespace string
 	var probeImage string
+	var probeOSImage string
 	var registryPort int
 	var registryProtocol string
 	var registryURL string
@@ -71,6 +72,7 @@ func main() {
 	flag.StringVar(&registryProtocol, "registry-protocol", "http", "The protocol to use for the registry.")
 	flag.IntVar(&registryPort, "registry-port", 8000, "The port to use for the registry.")
 	flag.StringVar(&probeImage, "probe-image", "", "Image for the first boot probing of a Server.")
+	flag.StringVar(&probeOSImage, "probe-os-image", "", "OS image for the first boot probing of a Server.")
 	flag.StringVar(&managerNamespace, "manager-namespace", "default", "Namespace the manager is running in.")
 	flag.BoolVar(&insecure, "insecure", true, "If true, use http instead of https for connecting to a BMC.")
 	flag.StringVar(&macPrefixesFile, "mac-prefixes-file", "", "Location of the MAC prefixes file.")
@@ -90,6 +92,11 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	if probeOSImage == "" {
+		setupLog.Error(nil, "probe OS image must be set")
+		os.Exit(1)
+	}
 
 	// Load MACAddress DB
 	macPRefixes := &macdb.MacPrefixes{}
@@ -194,6 +201,7 @@ func main() {
 		Insecure:         insecure,
 		ManagerNamespace: managerNamespace,
 		ProbeImage:       probeImage,
+		ProbeOSImage:     probeOSImage,
 		RegistryURL:      registryURL,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Server")

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -59,6 +59,7 @@ type ServerReconciler struct {
 	ManagerNamespace string
 	ProbeImage       string
 	RegistryURL      string
+	ProbeOSImage     string
 }
 
 //+kubebuilder:rbac:groups=metal.ironcore.dev,resources=bmcs,verbs=get;list;watch
@@ -249,7 +250,7 @@ func (r *ServerReconciler) applyBootConfigurationAndIgnitionForDiscovery(ctx con
 			IgnitionSecretRef: &v1.LocalObjectReference{
 				Name: server.Name,
 			},
-			Image: r.ProbeImage,
+			Image: r.ProbeOSImage,
 		},
 	}
 

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Server Controller", func() {
 		}
 		Eventually(Object(bootConfig)).Should(SatisfyAll(
 			HaveField("Spec.ServerRef", v1.LocalObjectReference{Name: server.Name}),
-			HaveField("Spec.Image", "foo:latest"),
+			HaveField("Spec.Image", "fooOS:latest"),
 			HaveField("Spec.IgnitionSecretRef", &v1.LocalObjectReference{Name: server.Name}),
 			HaveField("Status.State", metalv1alpha1.ServerBootConfigurationStatePending),
 		))

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -180,6 +180,7 @@ func SetupTest() *corev1.Namespace {
 			Insecure:         true,
 			ManagerNamespace: ns.Name,
 			ProbeImage:       "foo:latest",
+			ProbeOSImage:     "fooOS:latest",
 			RegistryURL:      registryURL,
 		}).SetupWithManager(k8sManager)).To(Succeed())
 


### PR DESCRIPTION
# Proposed Changes

Add a new flag `--probe-os-image` to configure the OS image to use for the first boot/initialization process.
