### PR TITLE
Add `RedfishLocal` BMC protocol type

### DIFF
--- a/bmc/bmc.go
+++ b/bmc/bmc.go
@@ -24,10 +24,10 @@ import (
 // BMC defines an interface for interacting with a Baseboard Management Controller.
 type BMC interface {
 	// PowerOn powers on the system.
-	PowerOn() error
+	PowerOn(systemUUID string) error
 
 	// PowerOff powers off the system.
-	PowerOff() error
+	PowerOff(systemUUID string) error
 
 	// Reset performs a reset on the system.
 	Reset() error

--- a/internal/controller/bmcutils.go
+++ b/internal/controller/bmcutils.go
@@ -67,6 +67,16 @@ func GetBMCClientFromBMC(ctx context.Context, c client.Client, bmcObj *metalv1al
 		if err != nil {
 			return nil, fmt.Errorf("failed to create Redfish client: %w", err)
 		}
+	case ProtocolRedfishLocal:
+		bmcAddress := fmt.Sprintf("%s://%s:%d", protocol, endpoint.Spec.IP, bmcObj.Spec.Protocol.Port)
+		username, password, err := GetBMCCredentialsFromSecret(bmcSecret)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get credentials from BMC secret: %w", err)
+		}
+		bmcClient, err = bmc.NewRedfishLocalBMCClient(ctx, bmcAddress, username, password, true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Redfish client: %w", err)
+		}
 	default:
 		return nil, fmt.Errorf("unsupported BMC protocol %s", bmcObj.Spec.Protocol.Name)
 	}

--- a/internal/controller/endpoint_controller_test.go
+++ b/internal/controller/endpoint_controller_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Endpoints Controller", func() {
 			HaveField("Spec.EndpointRef.Name", Equal(endpoint.Name)),
 			HaveField("Spec.BMCSecretRef.Name", Equal(bmc.Name)),
 			HaveField("Spec.Protocol", metalv1alpha1.Protocol{
-				Name: ProtocolRedfish,
+				Name: ProtocolRedfishLocal,
 				Port: 8000,
 			}),
 			HaveField("Spec.ConsoleProtocol", &metalv1alpha1.ConsoleProtocol{

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -126,7 +126,6 @@ var _ = Describe("Server Controller", func() {
 			HaveField("Status.Manufacturer", "Contoso"),
 			HaveField("Status.SKU", "8675309"),
 			HaveField("Status.SerialNumber", "437XR1138R2"),
-			HaveField("Status.PowerState", metalv1alpha1.ServerOnPowerState),
 			HaveField("Status.IndicatorLED", metalv1alpha1.OffIndicatorLED),
 			HaveField("Status.State", metalv1alpha1.ServerStateInitial),
 		))
@@ -143,9 +142,10 @@ var _ = Describe("Server Controller", func() {
 			bootConfig.Status.State = metalv1alpha1.ServerBootConfigurationStateReady
 		})).Should(Succeed())
 
-		By("Ensuring that the server is set to available")
+		By("Ensuring that the server is set to available and powered off")
 		Eventually(Object(server)).Should(SatisfyAll(
 			HaveField("Status.State", metalv1alpha1.ServerStateAvailable),
+			HaveField("Status.PowerState", metalv1alpha1.ServerOffPowerState),
 			HaveField("Status.NetworkInterfaces", Not(BeEmpty())),
 		))
 	})

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -143,7 +143,7 @@ func SetupTest() *corev1.Namespace {
 				{
 					MacPrefix:    "23",
 					Manufacturer: "Foo",
-					Protocol:     "Redfish",
+					Protocol:     "RedfishLocal",
 					Port:         8000,
 					Type:         "bmc",
 					DefaultCredentials: []macdb.Credential{


### PR DESCRIPTION
# Proposed Changes

In order to properly test the end to end flow against a local BMC emulator a new BMC protocol type `RedFishLocal` has been introduced. The main reason for that is that the `PowerOn` and `PowerOff` behaviour is different for varios BMC implementations.