### PR TITLE
Randomize registry port in test suite

### DIFF
--- a/internal/probe/probe_suite_test.go
+++ b/internal/probe/probe_suite_test.go
@@ -32,8 +32,8 @@ var (
 	probeAgent     *probe.Agent
 	registryServer *registry.Server
 
-	registryAddr = ":12345"
-	registryURL  = "http://localhost:12345"
+	registryAddr = ":5432"
+	registryURL  = "http://localhost:5432"
 	systemUUID   = "1234-5678"
 )
 

--- a/internal/registry/registry_suite_test.go
+++ b/internal/registry/registry_suite_test.go
@@ -29,8 +29,8 @@ import (
 
 var (
 	server         *registry.Server
-	testServerURL  = "http://localhost:12345"
-	testServerAddr = ":12345"
+	testServerURL  = "http://localhost:54321"
+	testServerAddr = ":54321"
 )
 
 func TestRegistry(t *testing.T) {


### PR DESCRIPTION
# Proposed Changes

To support the parallel execution of regitry tests we need to change the port of the registry.