### PR TITLE
Use host network when running `metalprobe`

### DIFF
--- a/internal/controller/testdata/ignition.go
+++ b/internal/controller/testdata/ignition.go
@@ -38,7 +38,7 @@ Restart=always
 ExecStartPre=-/usr/bin/docker stop metalprobe
 ExecStartPre=-/usr/bin/docker rm metalprobe
 ExecStartPre=/usr/bin/docker pull foo:latest
-ExecStart=/usr/bin/docker run --name metalprobe foo:latest --registry-url=http://localhost:12345 --server-uuid=38947555-7742-3448-3784-823347823834
+ExecStart=/usr/bin/docker run --network host --privileged --name metalprobe foo:latest --registry-url=http://localhost:12345 --server-uuid=38947555-7742-3448-3784-823347823834
 ExecStop=/usr/bin/docker stop metalprobe
 [Install]
 WantedBy=multi-user.target`,

--- a/internal/ignition/default.go
+++ b/internal/ignition/default.go
@@ -48,7 +48,7 @@ systemd:
        ExecStartPre=-/usr/bin/docker stop metalprobe
        ExecStartPre=-/usr/bin/docker rm metalprobe
        ExecStartPre=/usr/bin/docker pull {{.Image}}
-       ExecStart=/usr/bin/docker run --name metalprobe {{.Image}} {{.Flags}}
+       ExecStart=/usr/bin/docker run --network host --privileged --name metalprobe {{.Image}} {{.Flags}}
        ExecStop=/usr/bin/docker stop metalprobe
        [Install]
        WantedBy=multi-user.target


### PR DESCRIPTION
# Proposed Changes

Use host network when running `metalprobe`.