### PR TITLE
Ensure `ServerBootConfiguration` removal on `Server` available state

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -70,7 +70,7 @@ func main() {
 
 	flag.StringVar(&registryURL, "registry-url", "", "The URL of the registry.")
 	flag.StringVar(&registryProtocol, "registry-protocol", "http", "The protocol to use for the registry.")
-	flag.IntVar(&registryPort, "registry-port", 8000, "The port to use for the registry.")
+	flag.IntVar(&registryPort, "registry-port", 10000, "The port to use for the registry.")
 	flag.StringVar(&probeImage, "probe-image", "", "Image for the first boot probing of a Server.")
 	flag.StringVar(&probeOSImage, "probe-os-image", "", "OS image for the first boot probing of a Server.")
 	flag.StringVar(&managerNamespace, "manager-namespace", "default", "Namespace the manager is running in.")

--- a/internal/controller/bmc_controller.go
+++ b/internal/controller/bmc_controller.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+
 	metalv1alpha1 "github.com/afritzler/metal-operator/api/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/ironcore-dev/controller-utils/clientutils"
@@ -99,6 +101,9 @@ func (r *BMCReconciler) reconcile(ctx context.Context, log logr.Logger, bmcObj *
 func (r *BMCReconciler) updateBMCStatusDetails(ctx context.Context, log logr.Logger, bmcObj *metalv1alpha1.BMC) error {
 	endpoint := &metalv1alpha1.Endpoint{}
 	if err := r.Get(ctx, client.ObjectKey{Name: bmcObj.Spec.EndpointRef.Name}, endpoint); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
 		return fmt.Errorf("failed to get Endpoints for BMC: %w", err)
 	}
 	log.V(1).Info("Got Endpoints for BMC", "Endpoints", endpoint.Name)

--- a/internal/controller/serverbootconfiguration_controller.go
+++ b/internal/controller/serverbootconfiguration_controller.go
@@ -149,7 +149,7 @@ func (r *ServerBootConfigurationReconciler) removeServerBootConfigRef(ctx contex
 
 	serverBase := server.DeepCopy()
 	server.Spec.BootConfigurationRef = nil
-	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); err != nil {
+	if err := r.Patch(ctx, server, client.MergeFrom(serverBase)); !apierrors.IsNotFound(err) {
 		return err
 	}
 


### PR DESCRIPTION
# Proposed Changes

- Remove `ServerBootConfiguration` when `Server` turns ready
- Switch default registry port to 10000
- Fix not found errors and implement proper re-queueing