### PR TITLE
Add RestartSec in default ignition

### DIFF
--- a/internal/controller/testdata/ignition.go
+++ b/internal/controller/testdata/ignition.go
@@ -28,6 +28,7 @@ systemd:
         Description=Install Docker
         Before=metalprobe.service
         [Service]
+        RestartSec=15
         Type=oneshot
         RemainAfterExit=yes
         ExecStart=/usr/bin/apt-get update
@@ -42,6 +43,7 @@ systemd:
         [Unit]
         Description=Run My Docker Container
         [Service]
+        RestartSec=15
         Restart=always
         ExecStartPre=-/usr/bin/docker stop metalprobe
         ExecStartPre=-/usr/bin/docker rm metalprobe

--- a/internal/ignition/default.go
+++ b/internal/ignition/default.go
@@ -40,6 +40,7 @@ systemd:
         Description=Install Docker
         Before=metalprobe.service
         [Service]
+        RestartSec=15
         Type=oneshot
         RemainAfterExit=yes
         ExecStart=/usr/bin/apt-get update
@@ -54,6 +55,7 @@ systemd:
         [Unit]
         Description=Run My Docker Container
         [Service]
+        RestartSec=15
         Restart=always
         ExecStartPre=-/usr/bin/docker stop metalprobe
         ExecStartPre=-/usr/bin/docker rm metalprobe


### PR DESCRIPTION
# Proposed Changes
For certain environments such as Dell Hardware, it is observed that the restart of the Metalprobe unit was too fast leading to overall failure. This change slows the restarts, giving more time to initialization of Docker+Interfaces. 

Fixes #